### PR TITLE
Fix direct channel links

### DIFF
--- a/client/components/App.vue
+++ b/client/components/App.vue
@@ -68,12 +68,6 @@ export default defineComponent({
 		provide(contextMenuKey, contextMenu);
 		provide(confirmDialogKey, confirmDialog);
 
-		// Since sign in redirect is disabled for the Troll Room
-		// add a custom redirect on initial load here
-		onMounted(() => {
-			void navigate("Livestream");
-		});
-
 		const viewportClasses = computed(() => {
 			return {
 				notified: store.getters.highlightCount > 0,

--- a/client/components/NetworkForm.vue
+++ b/client/components/NetworkForm.vue
@@ -486,6 +486,8 @@ export type NetworkFormDefaults = Partial<ClientNetwork> & {
 	join?: string;
 };
 
+const defaultChannel = '#NoAgenda';
+
 export default defineComponent({
 	name: "NetworkForm",
 	components: {
@@ -508,10 +510,16 @@ export default defineComponent({
 		const store = useStore();
 		const config = ref(store.state.serverConfiguration);
 		const trollroomNick = ref(window.localStorage.getItem('trollroom-nick') ?? props.defaults?.nick);
-		const trollroomJoin = ref(window.localStorage.getItem('trollroom-join') ?? props.defaults?.join);
+		const trollroomJoin = ref(window.localStorage.getItem('trollroom-join') ?? defaultChannel);
 		const trollroomPassword = ref(window.localStorage.getItem('trollroom-password') ?? '');
 		const previousUsername = ref(props.defaults?.username);
 		const displayPasswordField = ref(false);
+
+		// Inherit join channels from params, but always join default channel(s).
+		const join = props.defaults?.join;
+		if (typeof join === 'string' && join.toLowerCase() !== defaultChannel.toLowerCase()) {
+			trollroomJoin.value = trollroomJoin.value + ',' + join;
+		}
 
 		const resetToDefaults = () => {
 			window.localStorage.removeItem('trollroom-nick');
@@ -519,7 +527,7 @@ export default defineComponent({
 			window.localStorage.removeItem('trollroom-password');
 
 			trollroomNick.value = props.defaults?.nick;
-			trollroomJoin.value = props.defaults?.join;
+			trollroomJoin.value = defaultChannel;
 			trollroomPassword.value = '';
 		};
 

--- a/client/js/router.ts
+++ b/client/js/router.ts
@@ -108,14 +108,8 @@ const router = createRouter({
 });
 
 router.beforeEach((to, from, next) => {
-	// Disabled for the Troll Room
-	next();
-
-	return;
-
-	// If user is not yet signed in, wait for appLoaded state to change
-	// unless they are trying to open SignIn (which can be triggered in auth.js)
-	if (!store.state.appLoaded && to.name !== "SignIn") {
+	// If the socket.io isn't connected, wait until it's connected before going to the requested path
+	if (!store.state.appLoaded && to.name !== "Livestream") {
 		store.watch(
 			(state) => state.appLoaded,
 			() => next()

--- a/client/js/socket-events/init.ts
+++ b/client/js/socket-events/init.ts
@@ -21,8 +21,24 @@ socket.on("init", async function (data) {
 
 		socket.emit("setting:get");
 
-		// This part of the code was removed for the Troll Room
-		// The connection is now checked in the Connect window
+		try {
+			await router.isReady();
+		} catch (e: any) {
+			// if the router throws an error, it means the route isn't matched,
+			// so we can continue on.
+		}
+
+		if (await handleQueryParams()) {
+			// If we handled query parameters like irc:// links or just general
+			// connect parameters in public mode, then nothing to do here
+			return;
+		}
+
+		// If we are on an unknown route, then navigate to the Livestream route
+		if (!router.currentRoute?.value?.name) {
+			await navigate("Livestream");
+		}
+
 	}
 });
 


### PR DESCRIPTION
The Lounge lets you specify the default channel to connect to in the URL: https://thelounge.chat/docs/guides/network-overrides . For example, https://demo.thelounge.chat/?join=greenroom will automatically send you to the connect page with the channels field set to #greenroom . This is similar to KiwiIRC where you can specify the default channel in the url: https://kiwiirc.com/nextclient/irc.zeronode.net/greenroom

The changes made for the Troll Room seem to break this functionality and always sends you to the Livestream page regardless of the query parameters specified.

This PR adds this functionality back in while still directing the user to the Livestream page for the default route.