### PR TITLE
Watch for upstream Express 5 adoption

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
       time: "06:00"
       timezone: Europe/Amsterdam
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: express
+        versions: [">= 5.0.0"]
+      - dependency-name: "@types/express"
+        versions: [">= 5.0.0"]

--- a/.github/workflows/watch-upstream-express.yml
+++ b/.github/workflows/watch-upstream-express.yml
@@ -1,0 +1,25 @@
+name: Watch upstream Express version
+
+on:
+  schedule:
+    - cron: "17 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open issue when upstream adopts Express 5
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="$(curl --fail --silent --show-error https://raw.githubusercontent.com/thelounge/thelounge/master/package.json | jq -r '.dependencies.express')"
+          [[ "$version" == 5.* ]] || exit 0
+
+          title="Upstream adopted Express 5"
+          existing="$(gh issue list --repo "$GITHUB_REPOSITORY" --state all --limit 1000 --json title --jq ".[] | select(.title == \"$title\") | .title")"
+          [[ -n "$existing" ]] || gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body "thelounge/thelounge now uses Express $version. Remove the Dependabot ignore rules and retry the upgrade."


### PR DESCRIPTION
## Summary

Watch upstream The Lounge for Express 5 adoption while deferring Trollroom's major upgrade.

## Changes

- Ignore Express 5 and matching type updates in Dependabot.
- Check upstream weekly and open one deduplicated issue after Express 5 lands.
- Allow manual workflow runs.

## Testing

- `git diff --check`
- Parsed both YAML files successfully.
- Confirmed current upstream version is `4.20.0` and follows no-op path.

## Merge notes

Remove ignore rules when watcher opens its issue.
