### PR TITLE
fix: adapt linkify-it 6 integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "got": "15.1.0",
     "irc-framework": "github:kiwiirc/irc-framework#9578e59",
     "ldapjs": "2.3.3",
-    "linkify-it": "5.0.2",
+    "linkify-it": "6.1.0",
     "lodash": "4.18.1",
     "mime-types": "3.0.2",
     "node-forge": "1.4.0",

--- a/shared/linkify.ts
+++ b/shared/linkify.ts
@@ -1,4 +1,4 @@
-import LinkifyIt, {Match} from "linkify-it";
+import {LinkifyIt, Match} from "linkify-it";
 import tlds from "tlds";
 
 export type LinkPart = {
@@ -7,7 +7,7 @@ export type LinkPart = {
 	link: string;
 };
 
-const linkify = new LinkifyIt().tlds(tlds).tlds("onion", true);
+const linkify = new LinkifyIt({fuzzyLink: true, urlAuth: true}).tlds(tlds).tlds("onion", true);
 
 // Known schemes to detect in text
 const commonSchemes = [
@@ -28,7 +28,9 @@ const commonSchemes = [
 ];
 
 for (const schema of commonSchemes) {
-	linkify.add(schema + ":", "http:");
+	linkify.add(schema + ":", {
+		validate: (text, pos, self) => self.testSchemaAt(text, "http:", pos),
+	});
 }
 
 linkify.add("web+", {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3916,12 +3916,12 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-linkify-it@5.0.2:
-  version "5.0.2"
-  resolved "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz"
-  integrity sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==
+linkify-it@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-6.1.0.tgz#cd750d70fe9295eb7169e632ee67a4ff43e7f62d"
+  integrity sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==
   dependencies:
-    uc.micro "^2.0.0"
+    uc.micro "^3.0.0"
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -6084,10 +6084,10 @@ ua-parser-js@2.0.10:
     is-standalone-pwa "^0.1.1"
     ua-is-frozen "^0.1.2"
 
-uc.micro@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz"
-  integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
+uc.micro@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-3.0.0.tgz#64d6cb0bfe2a558ce0ec7c8c0dc88a02d898f506"
+  integrity sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==
 
 uint8array-extras@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
## Summary
- Updates `linkify-it` from 5.0.2 to 6.1.0.
- Uses v6 named exports and explicit validators/options matching existing link behavior.

## Verification
- `corepack yarn build`
- `corepack yarn test`

Supersedes #54.