### PR TITLE
fix: adapt read 6 prompt API

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "mime-types": "3.0.2",
     "node-forge": "1.4.0",
     "package-json": "10.0.1",
-    "read": "1.0.7",
+    "read": "6.0.0",
     "semver": "7.8.5",
     "socket.io": "4.8.3",
     "tlds": "1.261.0",

--- a/server/log.ts
+++ b/server/log.ts
@@ -1,5 +1,5 @@
 import colors from "chalk";
-import read from "read";
+import {read} from "read";
 
 function timestamp() {
 	const datetime = new Date().toISOString().split(".")[0].replace("T", " ");
@@ -31,7 +31,10 @@ const log = {
 		callback: (error, result, isDefault) => void
 	): void {
 		options.prompt = [timestamp(), colors.cyan("[PROMPT]"), options.text].join(" ");
-		read(options, callback);
+		read(options).then(
+			(result) => callback(null, result, false),
+			(error) => callback(error, undefined, false)
+		);
 	},
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4219,10 +4219,10 @@ ms@2.1.3, ms@^2.1.3:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-mute-stream@~0.0.4:
-  version "0.0.8"
-  resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz"
-  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+mute-stream@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-4.0.0.tgz#3b04c237748aa7a2c93d8b5093cb001eaca1fbeb"
+  integrity sha512-gSrprq0fJ3EiOErzjdIZrjysVVmJ4uu1QWfCDss5LypA5OXvrMje5Ym5z6V6RLyJ2eF87lasX7t6a0AnFvZblg==
 
 nanoid@^3.3.17:
   version "3.3.18"
@@ -5215,12 +5215,12 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-read@1.0.7:
-  version "1.0.7"
-  resolved "https://registry.npmjs.org/read/-/read-1.0.7.tgz"
-  integrity sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==
+read@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/read/-/read-6.0.0.tgz#755f0c3110a143060ca2ddc129ac657f97d589cf"
+  integrity sha512-Tg/LaEke7h9SDbp0xJJj53oa4s1VPPySVnxQF9nUS9DgA25M/ZCLk7RVF1kHjytC87XbkgQKmQ/79+DQgEIqLA==
   dependencies:
-    mute-stream "~0.0.4"
+    mute-stream "^4.0.0"
 
 readable-stream@^3.5.0:
   version "3.6.2"


### PR DESCRIPTION
## Summary
- Updates `read` from 1.0.7 to 6.0.0.
- Replaces callback API with v6 named-export Promise API.

## Verification
- `corepack yarn build`
- `corepack yarn test`

Supersedes #52.