### PR TITLE
build: update stylelint-config-standard to 29

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1,6 +1,6 @@
-@import "../../node_modules/normalize.css/normalize.css";
-@import "fontawesome.css";
-@import "../../node_modules/primer-tooltips/build/build.css";
+@import url("../../node_modules/normalize.css/normalize.css");
+@import url("fontawesome.css");
+@import url("../../node_modules/primer-tooltips/build/build.css");
 
 /* Allow tooltips via data-tooltip instead of aria-label to avoid
    duplicating accessible names on wrapper + child elements */
@@ -419,7 +419,7 @@ p {
 .channel-list-item[data-type="special"]::before { content: "\f03a"; /* http://fontawesome.io/icon/list/ */ }
 .channel-list-item[data-type="livestream"]::before { content: "\f130"; /* http://fontawesome.io/icon/microphone/ */ }
 
-.channel-list-item.has-draft:not(.active):not([data-type="lobby"])::before {
+.channel-list-item.has-draft:not(.active, [data-type="lobby"])::before {
 	content: "\f304"; /* https://fontawesome.com/icons/pen?style=solid */
 }
 

--- a/client/public/themes/morning.css
+++ b/client/public/themes/morning.css
@@ -1,4 +1,4 @@
-@import "default.css";
+@import url("default.css");
 
 :root {
 	--body-color: #f3f3f3;

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "socket.io-client": "4.8.3",
     "sortablejs": "1.15.7",
     "stylelint": "14.16.1",
-    "stylelint-config-standard": "24.0.0",
+    "stylelint-config-standard": "29.0.0",
     "ts-node": "10.9.2",
     "ts-sinon": "2.0.2",
     "tsx": "4.23.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5755,17 +5755,17 @@ stylehacks@^5.1.1:
     browserslist "^4.21.4"
     postcss-selector-parser "^6.0.4"
 
-stylelint-config-recommended@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz"
-  integrity sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==
+stylelint-config-recommended@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz#1c9e07536a8cd875405f8ecef7314916d94e7e40"
+  integrity sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==
 
-stylelint-config-standard@24.0.0:
-  version "24.0.0"
-  resolved "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-24.0.0.tgz"
-  integrity sha512-+RtU7fbNT+VlNbdXJvnjc3USNPZRiRVp/d2DxOF/vBDDTi0kH5RX2Ny6errdtZJH3boO+bmqIYEllEmok4jiuw==
+stylelint-config-standard@29.0.0:
+  version "29.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-29.0.0.tgz#4cc0e0f05512a39bb8b8e97853247d3a95d66fa2"
+  integrity sha512-uy8tZLbfq6ZrXy4JKu3W+7lYLgRQBxYTUUB88vPgQ+ZzAxdrvcaSUW9hOMNLYBnwH+9Kkj19M2DHdZ4gKwI7tg==
   dependencies:
-    stylelint-config-recommended "^6.0.0"
+    stylelint-config-recommended "^9.0.0"
 
 stylelint@14.16.1:
   version "14.16.1"


### PR DESCRIPTION
## Summary
- Updates `stylelint-config-standard` from 24.0.0 to 29.0.0.
- Updates equivalent CSS syntax required by new rules.

## Verification
- `corepack yarn test`
- `corepack yarn build`

Supersedes #50.