### PR TITLE
build: bump @fastify/busboy from 3.2.0 to 3.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "./public/**"
   ],
   "dependencies": {
-    "@fastify/busboy": "3.2.0",
+    "@fastify/busboy": "3.2.2",
     "bcryptjs": "3.0.3",
     "chalk": "6.0.0",
     "cheerio": "1.2.0",

--- a/server/plugins/uploader.ts
+++ b/server/plugins/uploader.ts
@@ -1,5 +1,5 @@
 import Config from "../config";
-import busboy, {BusboyHeaders} from "@fastify/busboy";
+import busboy, {BusboyHeaders, BusboyInstance} from "@fastify/busboy";
 import path from "path";
 import fs from "fs";
 import {fileTypeFromBuffer} from "file-type";
@@ -130,7 +130,7 @@ class Uploader {
 	}
 
 	static routeUploadFile(this: void, req: Request, res: Response) {
-		let busboyInstance: busboy | null | undefined;
+		let busboyInstance: BusboyInstance | null | undefined;
 		let uploadUrl: string | URL;
 		let randomName: string;
 		let destDir: fs.PathLike;
@@ -281,7 +281,7 @@ class Uploader {
 		});
 
 		// pipe request body to busboy for processing
-		return req.pipe(busboyInstance);
+		req.pipe(busboyInstance);
 	}
 
 	static getMaxFileSize() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -843,10 +843,10 @@
   resolved "https://registry.yarnpkg.com/@exodus/bytes/-/bytes-1.15.1.tgz#b13bc464ca162c17abf0837fb3a11aeab79e45d1"
   integrity sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==
 
-"@fastify/busboy@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-3.2.0.tgz#13ed8212f3b9ba697611529d15347f8528058cea"
-  integrity sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==
+"@fastify/busboy@3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-3.2.2.tgz#c35ca0fac4b644f5f56a7e179360568a5d7c997e"
+  integrity sha512-yXSS27qPExaXeuLvMRMXOLtpipzfQYNjG3FkunDWKGfMYjKuhFXko9CVzqxm8jcF+lmtS9Fd89QNdh9XDjnbNg==
 
 "@fortawesome/fontawesome-free@7.3.1":
   version "7.3.1"


### PR DESCRIPTION
Supersedes Dependabot PR #74. The patch release fixes multipart-upload security advisories and replaces the removed Busboy type with `BusboyInstance`.\n\nValidation: `yarn test` (288 tests) and `yarn build`.