### PR TITLE
build(deps-dev): bump @types/node from 22.19.17 to 26.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@types/lodash": "4.17.25",
     "@types/mime-types": "3.0.1",
     "@types/mousetrap": "1.6.15",
-    "@types/node": "22.19.17",
+    "@types/node": "26.4.0",
     "@types/read": "3.0.0",
     "@types/semver": "7.8.0",
     "@types/sortablejs": "1.15.9",

--- a/server/identification.ts
+++ b/server/identification.ts
@@ -93,7 +93,7 @@ class Identification {
 		});
 	}
 
-	respondToIdent(socket: Socket, buffer: Buffer) {
+	respondToIdent(socket: Socket, buffer: Buffer | string) {
 		if (!socket.remoteAddress) {
 			log.warn("identd: no remote address");
 			return;

--- a/server/server.ts
+++ b/server/server.ts
@@ -184,7 +184,6 @@ export default async function (
 		};
 	}
 
-	// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
 	server.on("error", (err) => log.error(`${err}`));
 
 	server.listen(listenParams, () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1414,19 +1414,12 @@
   resolved "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.15.tgz"
   integrity sha512-qL0hyIMNPow317QWW/63RvL1x5MVMV+Ru3NaY9f/CuEpCqrmb7WeuK2071ZY5hczOnm38qExWM2i2WtkXLSqFw==
 
-"@types/node@*", "@types/node@>=10.0.0":
-  version "25.9.1"
-  resolved "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz"
-  integrity sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==
+"@types/node@*", "@types/node@26.4.0", "@types/node@>=10.0.0":
+  version "26.4.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-26.4.0.tgz#4c4ca071c42241fe602741d02999f16b4e64c468"
+  integrity sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==
   dependencies:
-    undici-types ">=7.24.0 <7.24.7"
-
-"@types/node@22.19.17":
-  version "22.19.17"
-  resolved "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz"
-  integrity sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==
-  dependencies:
-    undici-types "~6.21.0"
+    undici-types "~8.3.0"
 
 "@types/node@^14.6.1":
   version "14.18.63"
@@ -6168,15 +6161,10 @@ undate@0.3.0, undate@^0.3.0:
   resolved "https://registry.npmjs.org/undate/-/undate-0.3.0.tgz"
   integrity sha512-ssH8QTNBY6B+2fRr3stSQ+9m2NT8qTaun3ExTx5ibzYQvP7yX4+BnX0McNxFCvh6S5ia/DYu6bsCKQx/U4nb/Q==
 
-"undici-types@>=7.24.0 <7.24.7":
-  version "7.24.6"
-  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz"
-  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
-
-undici-types@~6.21.0:
-  version "6.21.0"
-  resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
-  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+undici-types@~8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
+  integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
 undici@^7.19.0:
   version "7.29.0"


### PR DESCRIPTION
Supersedes #90. Node 26 types correctly model socket `data` as `string | Buffer`; the existing parser accepts either. Removes the now-unused ESLint suppression exposed by the updated error type.\n\nValidated locally with `corepack yarn test` (288 tests) and `corepack yarn build`.